### PR TITLE
Add Intel MKL linking option

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,8 @@ FFLAGS =  -fno-align-commons -fallow-argument-mismatch -O1  #-ffree-form #-Wall 
 #FFLAGS =  -fno-align-commons -g -ffpe-trap=zero,invalid,overflow,underflow  #-ffree-form #-Wall # debug version!
 LINKFLAGS = -static-libgcc -fopenmp -llapack -lblas -lfftw3 -fno-align-commons # normal version 
 #LINKFLAGS = -static-libgcc -fopenmp -llapack -lblas -lfftw3 -fno-align-commons -g -ffpe-trap=zero,invalid,overflow,underflow # debug version!
+# link against Intel MKL, has been tested with GNU Fortran MPI compiler
+#LINKFLAGS = -static-libgcc -fopenmp -L${MKLROOT}/lib/intel64 -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl
 
 
 # Targets by default


### PR DESCRIPTION
Since Intel MKL math library is widely used in scientific computing, I add a linking option so that Caracal can invoking BLAS, LAPACK & FFTW provided by MKL. The tests were done with GNU MPI Fortran compiler gfortran 8.5.0 & 9.4.0, and MKL 2022.0.1 provided by Intel oneAPI. It also requires `-Wno-argument-mismatch` instead of `-fallow-argument-mismatch` for old version gfortran compilers.